### PR TITLE
v1.0.20

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,7 +19,7 @@ dockers:
       - "docker.io/jamcswain/dmrhub:v{{ .Major }}.{{ .Minor }}-amd64"
       - "docker.io/jamcswain/dmrhub:latest-amd64"
     use: buildx
-    goarch: arm64
+    goarch: amd64
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"

--- a/internal/sdk/version.go
+++ b/internal/sdk/version.go
@@ -30,5 +30,5 @@ var (
 	GitCommit string
 
 	// Version of the program
-	Version = "1.0.19" //nolint:golint,gochecknoglobals
+	Version = "1.0.20" //nolint:golint,gochecknoglobals
 )


### PR DESCRIPTION
Fixes the issue where amd64 Docker images actually pull the arm64 binary.

Fixes: #147 