### PR TITLE
Added an option to disable RadioID ID check on new user registration …

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,7 @@ type Config struct {
 	AdminEmail               string
 	EnableEmail              bool
 	CanonicalHost            string
+	EnforceRadioid		 bool
 }
 
 var currentConfig atomic.Value //nolint:golint,gochecknoglobals
@@ -146,6 +147,7 @@ func loadConfig() Config {
 		AdminEmail:               os.Getenv("ADMIN_EMAIL"),
 		EnableEmail:              os.Getenv("ENABLE_EMAIL") != "",
 		CanonicalHost:            os.Getenv("CANONICAL_HOST"),
+		EnforceRadioid:		  os.Getenv("ENFORCE_RADIOID") != "0",
 	}
 	if tmpConfig.RedisHost == "" {
 		tmpConfig.RedisHost = "localhost:6379"

--- a/internal/http/api/controllers/v1/users/users.go
+++ b/internal/http/api/controllers/v1/users/users.go
@@ -83,14 +83,18 @@ func POSTUser(c *gin.Context) {
 		logging.Errorf("POSTUser: JSON data is invalid: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"error": "JSON data is invalid"})
 	} else {
-		if !userdb.IsValidUserID(json.DMRId) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "DMR ID is not valid"})
-			return
+		if config.GetConfig().EnforceRadioid {
+			if !userdb.IsValidUserID(json.DMRId) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "DMR ID is not valid"})
+				return
+			}
+
+			if !userdb.ValidUserCallsign(json.DMRId, json.Callsign) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Callsign does not match DMR ID"})
+				return
+			}
 		}
-		if !userdb.ValidUserCallsign(json.DMRId, json.Callsign) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Callsign does not match DMR ID"})
-			return
-		}
+		
 		isValid, errString := json.IsValidUsername()
 		if !isValid {
 			c.JSON(http.StatusBadRequest, gin.H{"error": errString})


### PR DESCRIPTION
…for private deployments through the env variable ENFORCE_RADIOID, default is enforce, use ENFORCE_RADIOID=0 to disable